### PR TITLE
Add array type declarations for autocomplete

### DIFF
--- a/src/Models/JiraChangelog.php
+++ b/src/Models/JiraChangelog.php
@@ -99,7 +99,7 @@ class JiraChangelog
     }
 
     /**
-     * @return array
+     * @return array<\JiraWebhook\Models\JiraChangelogItem>
      */
     public function getItems()
     {

--- a/src/Models/JiraIssueComments.php
+++ b/src/Models/JiraIssueComments.php
@@ -110,7 +110,7 @@ class JiraIssueComments
     /**************************************************/
 
     /**
-     * @return array
+     * @return array<\JiraWebhook\Models\JiraIssueComment>
      */
     public function getComments()
     {


### PR DESCRIPTION
 - Specifies type of array items returned by `getItems()` in `JiraChangelog`
 - Specifies type of array items returned by `getComments()` in `JiraIssueComments`

These changes allows IDEs to display autocomplete and enables other useful features.